### PR TITLE
Fix: Secrets

### DIFF
--- a/src/YoloKonsole/Program.cs
+++ b/src/YoloKonsole/Program.cs
@@ -63,8 +63,8 @@ __  ______  __    ____  __
                 .AddEnvironmentVariables();
 
             // add file-based secrets
-            var secretsPath = Environment.GetEnvironmentVariable("YOLO_SECRETS_PATH");
-            if (secretsPath != null && Directory.Exists(secretsPath))
+            var secretsPath = Path.Combine(Directory.GetCurrentDirectory(), "secrets");
+            if (Directory.Exists(secretsPath))
             {
                 builder.AddKeyPerFile(secretsPath, optional: true);
             }

--- a/src/YoloKonsole/setup-secrets.ps1
+++ b/src/YoloKonsole/setup-secrets.ps1
@@ -1,6 +1,5 @@
 # Create secrets directory
 $secretsPath = Join-Path $PWD "secrets"
-$env:YOLO_SECRETS_PATH = $secretsPath
 New-Item -Path $secretsPath -ItemType Directory -Force
 
 # Prompt for secrets securely


### PR DESCRIPTION
Do not use env var for secrets path; just assume the "secrets" sub-dir instead

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Secrets configuration now uses a fixed directory path, simplifying the setup process without requiring manual environment variable configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->