### PR TITLE
Fix: Robotwealth API - change type of "success" to bool

### DIFF
--- a/src/RobotWealth.Api/Data/RwApiResponse.cs
+++ b/src/RobotWealth.Api/Data/RwApiResponse.cs
@@ -13,5 +13,5 @@ public record RwApiResponse<T> : IApiResponse<T>
     public required long LastUpdated { get; init; }
 
     [JsonPropertyName("success")]
-    public required string Success { get; init; }
+    public required bool Success { get; init; }
 }

--- a/test/Robotwealth.Api.Test/Data/volatilities.json
+++ b/test/Robotwealth.Api.Test/Data/volatilities.json
@@ -52,5 +52,5 @@
     }
   ],
   "last_updated": 1759761547,
-  "success": "true"
+  "success": true
 }

--- a/test/Robotwealth.Api.Test/Data/weights.json
+++ b/test/Robotwealth.Api.Test/Data/weights.json
@@ -92,5 +92,5 @@
     }
   ],
   "last_updated": 1759761545,
-  "success": "true"
+  "success": true
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Corrected API response handling to properly use boolean values for success status instead of strings, ensuring accurate data type validation and processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->